### PR TITLE
handled windows path format

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,7 +26,11 @@ function gulpCssAdjustPath(needle) {
 
     // Creating a stream through which each file will pass
     return through.obj(function (file, enc, cb) {
-        pathArray = file.path.substring(file.base.length).split('/');
+        //windows uses backward slash in file path
+        var isWin = process.platform === "win32";
+        var separator = isWin ? '\\' : '/';
+        
+        pathArray = file.path.substring(file.base.length).split(separator);
         replacement = '$1' + '../' + Array(pathArray.length).join('../') + '$2';
 
         if (file.isNull()) {


### PR DESCRIPTION
@hurrtz Please review.

Desc:
In windows, the file path contains backward slash instead of forward slash like in mac/linux. This make to replacement always equal to '$1../$2' which makes the path incorrect, so added a check for OS to find the correct separator.